### PR TITLE
Find next closest critical ratio to suggest overbooking

### DIFF
--- a/frontend/src/reducer.js
+++ b/frontend/src/reducer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-fallthrough */
 const initialState = {
   currentGame: 1,
   games: {
@@ -215,24 +216,21 @@ function reducer(state = initialState, action = {}) {
       };
     }
     case "SUGGEST_OVERBOOKING": {
-      let closest = ratios.reduce(function(prev, curr) {
-        return Math.abs(curr - action.payload) < Math.abs(prev - action.payload)
-          ? curr
-          : prev;
-      });
-
-      const suggested = ratios.findIndex(ratio => ratio === closest);
-
-      return {
-        ...state,
-        games: {
-          ...state.games,
-          [state.currentGame]: {
-            ...state.games[state.currentGame],
-            suggestedOverbooking: suggested
-          }
+      for (let i = 0; i < ratios.length; i++) {
+        if (ratios[i] >= action.payload) {
+          const suggested = ratios.findIndex(ratio => ratio === ratios[i]);
+          return {
+            ...state,
+            games: {
+              ...state.games,
+              [state.currentGame]: {
+                ...state.games[state.currentGame],
+                suggestedOverbooking: suggested
+              }
+            }
+          };
         }
-      };
+      }
     }
     case "RESET": {
       return initialState;

--- a/frontend/src/views/overbooking-number.js
+++ b/frontend/src/views/overbooking-number.js
@@ -135,8 +135,6 @@ function OverbookingNumber() {
   }
   const revenue = value * pricePerSeat + totalSeats * pricePerSeat;
 
-  const bulletPosition = (value / totalSeats) * 77 + "%";
-
   function handleSubmit(event) {
     event.preventDefault();
   }


### PR DESCRIPTION
**Status**
Ready

**Related Issue(s)**
Close #59

**Implementation Notes**
- Change reducer SUGGEST_OVERBOOKING function in reducer so that it finds the next closest critical ratio in order to suggest the correct overbooking